### PR TITLE
Add custom config plugin to add missing gif dependencies

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,6 +28,9 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      "./config-plugins/with-android-gif"
+    ]
   }
 }

--- a/config-plugins/with-android-gif.js
+++ b/config-plugins/with-android-gif.js
@@ -1,0 +1,46 @@
+const {
+  createRunOncePlugin, 
+  WarningAggregator,
+  withAppBuildGradle,
+} = require('@expo/config-plugins');
+
+const GIF_LIBRARY = { name: 'com.facebook.fresco:animated-gif', version: '2.0.0' };
+
+/**
+ * Add Gif animation support for Android.
+ * It does that by adding the missing Gradle libraries for gif animations.
+ * @see https://reactnative.dev/docs/image#gif-and-webp-support-on-android
+ */
+const withAndroidGif = (config) => {
+  return withAppBuildGradle(config, config => {
+    if (config.modResults.language === 'groovy') {
+      config.modResults.contents = addGradleDependency(config.modResults.contents, GIF_LIBRARY);  
+    } else {
+      WarningAggregator.addWarningAndroid(
+        'android-gif-support',
+        `Cannot add GIF libraries to project build.gradle if it's not groovy`
+      );
+    }
+    return config;
+  });
+};
+
+module.exports = createRunOncePlugin(withAndroidGif, 'android-gif-support', '1.0.0');
+
+/**
+ * @param {string} buildGradle - android/app/build.gradle file contents
+ * @param {Object} library - gradle library information
+ * @param {string} library.name - the full class path and name of the library
+ * @param {string} library.version - the version of the library
+ */
+ function addGradleDependency(buildGradle, library) {
+  if (buildGradle.includes(library.name)) {
+    return buildGradle;
+  }
+
+  return buildGradle.replace(
+    /dependencies\s?{/,
+    `dependencies {
+    implementation "${library.name}:${library.version}"`
+  );
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-native-web": "~0.13.12"
   },
   "devDependencies": {
-    "@babel/core": "^7.9.0"
+    "@babel/core": "^7.9.0",
+    "@expo/config-plugins": "^3.0.5"
   },
   "private": true
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,7 +1150,7 @@
     xcode "^3.0.1"
     xml2js "^0.4.23"
 
-"@expo/config-plugins@3.0.5", "@expo/config-plugins@^3.0.0":
+"@expo/config-plugins@3.0.5", "@expo/config-plugins@^3.0.0", "@expo/config-plugins@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@expo/config-plugins/-/config-plugins-3.0.5.tgz#9390403d7bf49bf35219c0922bf7bf6d81390988"
   integrity sha512-hHKr6i201QG16ms93XiXwcI1IhDYhITCRt7hWNO1UPxt2Cm7yDOG2YoGkauP0V/nAN3TEocDYbCrltGFBdoCTg==


### PR DESCRIPTION
This adds support for animated GIFs by adding the missing Gradle dependencies in EAS.

- It's a simple hook, based on the [Expo config plugins documentation](https://docs.expo.io/guides/config-plugins/)
- Adding the library [documented by React Native](https://reactnative.dev/docs/image#gif-and-webp-support-on-android)

I also double-checked this with an EAS build, [here is the APK](https://expo.io/artifacts/eas/ttEPSCUpPkAU1e3rwA9Q2Q.apk).